### PR TITLE
Don't crash on files with no Hough lines

### DIFF
--- a/alyn/deskew.py
+++ b/alyn/deskew.py
@@ -22,7 +22,7 @@ class Deskew:
 
         img = io.imread(self.input_file)
         res = self.skew_obj.process_single_file()
-        angle = res['Estimated Angle']
+        angle = res.get('Estimated Angle', 0)
 
         if angle >= 0 and angle <= 90:
             rot_angle = angle - 90 + self.r_angle


### PR DESCRIPTION
If no lines are detected, `detect_skew` returns `{"Image File": img_file, "Message": "Bad Quality"}`, which then crashes `deskew` as the key `Estimated Angle` can not be found. Simple fix to propose a default value.